### PR TITLE
Addition of makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,20 +3,25 @@ SENTRY_PROJECT=flutter
 VERSION=`sentry-cli releases propose-version`
 PREFIX=./obfuscated_symbols
 
-all:
+all:.PHONY
 	build_apk create_sentry_release associate_commits upload_symbols install_on_running_emulator
 
-build_apk:
+build_apk:.PHONY
 	flutter build apk --obfuscate --split-debug-info=./obfuscated_symbols
 
-upload_symbols:
+
+upload_symbols:.PHONY
 	sentry-cli upload-dif -o $(SENTRY_ORG) -p $(SENTRY_PROJECT) --wait $(PREFIX)
 
-create_sentry_release:
+
+create_sentry_release:.PHONY
 	sentry-cli releases -o $(SENTRY_ORG) new -p $(SENTRY_PROJECT) $(VERSION)
 
-associate_commits:
+associate_commits:.PHONY
 	sentry-cli releases -o $(SENTRY_ORG) -p $(SENTRY_PROJECT) set-commits --auto $(VERSION)
 
-install_on_running_emulator:
+
+install_on_running_emulator:.PHONY
 	flutter install
+
+.PHONY: all build_apk upload_symbols create_sentry_release associate_commits install_on_running_emulator

--- a/lib/checkout.dart
+++ b/lib/checkout.dart
@@ -83,7 +83,6 @@ class _CheckoutViewState extends State<CheckoutView> {
                   GradientButton(
                     text: "Place your order",
                     onPressed: () {
-                      throw Exception("testing exception");
                       completeCheckout(_key);
                     },
                     height: 50.0,


### PR DESCRIPTION
 - Demo now performes the following actions during build
 - Build akp, obfuscate dart code, split out debug files
 - Create sentry release, associate commits, upload symbols
 - Install sentry_flutter_app on compatable emulator that is currently running x86 64 arm64