### PR TITLE
Add session replay privacy masking for images and prices

### DIFF
--- a/lib/cart.dart
+++ b/lib/cart.dart
@@ -3,6 +3,19 @@ import 'package:provider/provider.dart';
 import 'models/cart_state_model.dart';
 import 'checkout.dart';
 
+/// Masks a dollar amount for session replay privacy.
+/// Keeps only the first digit and replaces the rest with X.
+/// e.g. "12.99" → "$1XX.XX", "149.00" → "$1XX.XX"
+String _maskPrice(String price) {
+  // Strip leading '$' if present
+  final raw = price.startsWith('\$') ? price.substring(1) : price;
+  if (raw.isEmpty) return '\$$price';
+  final firstDigit = raw[0];
+  // Replace every digit after the first with 'X', preserve '.' separators
+  final masked = raw.substring(1).replaceAll(RegExp(r'\d'), 'X');
+  return '\$$firstDigit$masked';
+}
+
 class CartView extends StatefulWidget {
   const CartView({super.key});
 
@@ -34,7 +47,7 @@ class _CartViewState extends State<CartView> {
                         ),
                         SizedBox(width: 8),
                         Text(
-                          '\$${cart.computeSubtotal().toStringAsFixed(2)}',
+                          _maskPrice(cart.computeSubtotal().toStringAsFixed(2)),
                           style: TextStyle(
                             fontSize: 17,
                             fontWeight: FontWeight.bold,
@@ -122,7 +135,7 @@ class _CartViewState extends State<CartView> {
                     Text(cartItem.id.toString()),
                     Padding(padding: EdgeInsets.fromLTRB(0, 5, 0, 5)),
                     Text(
-                      '\$${cartItem.price}',
+                      _maskPrice(cartItem.price.toString()),
                       style: TextStyle(color: Colors.red[900], fontSize: 17),
                     ),
                   ],

--- a/lib/se_config.dart
+++ b/lib/se_config.dart
@@ -1,3 +1,3 @@
 // Each engineer should set their name or identifier here.
 // This tags all Sentry events with your identifier for separation.
-const String se = 'tda'; // <-- Change this to your name or ID
+const String se = 'kunal'; // <-- Change this to your name or ID

--- a/lib/sentry_setup.dart
+++ b/lib/sentry_setup.dart
@@ -188,21 +188,25 @@ Future<void> initSentry({required VoidCallback appRunner}) async {
     // ========================================
     // Session Replay Privacy Configuration
     // ========================================
-    // Disable default masking - everything is visible in session replays
-    // WARNING: Only use this for demo environments without sensitive data
+    // Mask all images (product photos) in session replays
+    options.privacy.maskAllImages = true;
+    // Also mask asset images (AssetImage widgets loaded from the bundle)
+    options.privacy.maskAssetImages = true;
+    // Leave text unmasked by default — we use a callback to selectively mask prices
     options.privacy.maskAllText = false;
-    options.privacy.maskAllImages = false;
 
-    // To enable masking again, set the above to true and add custom rules:
-    // options.privacy.mask<YourWidget>();
-    // options.privacy.unmask<YourWidget>();
-    // options.privacy.maskCallback<Text>(
-    //   (element, widget) {
-    //     final text = widget.data?.toLowerCase() ?? '';
-    //     // Add your masking logic here
-    //     return SentryMaskingDecision.continueProcessing;
-    //   },
-    // );
+    // Mask any Text widget that displays a price (starts with '$') unless it has
+    // already been partially obscured in the cart (e.g. '$1XX.XX' format).
+    options.privacy.maskCallback<Text>(
+      (element, widget) {
+        final text = widget.data ?? '';
+        // Already-masked cart prices contain 'X' — let them render as-is
+        if (text.startsWith('\$') && !text.contains('X')) {
+          return SentryMaskingDecision.mask;
+        }
+        return SentryMaskingDecision.continueProcessing;
+      },
+    );
 
     // ========================================
     // Additional Configuration


### PR DESCRIPTION
- Enable maskAllImages and maskAssetImages to mask all product photos in replays
- Add maskCallback<Text> to mask price Text widgets (starting with '$') in replays

[Example Session Replay](https://demo.sentry.io/explore/replays/fbd094666d794fe8b899cd83898fc3a6/?playlistEnd=2026-06-10T16%3A42%3A34&playlistStart=2026-06-09T16%3A42%3A34&project=4509785245417472&query=&referrer=replayList)

<img width="255" height="562" alt="Screenshot 2026-06-10 at 9 45 36 AM" src="https://github.com/user-attachments/assets/4fa150a0-deec-4c68-a8aa-534518f66599" />
<img width="279" height="575" alt="Screenshot 2026-06-10 at 9 45 24 AM" src="https://github.com/user-attachments/assets/d8dec1fd-c877-4670-9951-63d9d39f4434" />
