### PR TITLE
chore: unify Sentry release to package-qualified name (com.example.empower_flutter@…)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 # ========================================
 SENTRY_AUTH_TOKEN=your_auth_token
 SENTRY_DSN=your_dsn
-SENTRY_RELEASE=empower_flutter@9.14.0+1  # Format: appname@version+build
+SENTRY_RELEASE=com.example.empower_flutter@9.22.0+1  # Format: <applicationId>@version+build (matches the build identifier used by Build Distribution)
 SENTRY_ENVIRONMENT=your_environment
 
 # ========================================


### PR DESCRIPTION
## Summary
Follow-up to #23. Sets `SENTRY_RELEASE` in `.env.example` to the **package-qualified** form `com.example.empower_flutter@<version>+<build>` so the app's release matches the identifier **Build Distribution** derives from the APK.

## Why
`sentry-cli build upload` (Build Distribution / size analysis) keys builds by the APK's `applicationId`+version (`com.example.empower_flutter@9.22.0+1`), not by the free-form `SENTRY_RELEASE`. With the bare `empower_flutter@…` release, events/symbols landed on one release while builds landed on another. Using the package-qualified name makes **events, debug symbols, web source maps, ProGuard mapping, and builds all share one release**.

This works because `sentry_dart_plugin` reads `SENTRY_RELEASE` from the env, `demo.sh`'s `get_release_name` already emits `com.example.…`, and Build Distribution reads the same identity from the APK — so all sources now agree.

## Change
- `.env.example`: `SENTRY_RELEASE=com.example.empower_flutter@9.22.0+1` (+ clarifying comment). (`.env` is gitignored; updated locally.)

Verified by rebuilding/uploading: the release build now creates only `com.example.empower_flutter@9.22.0+1`, with Dart symbols, ProGuard, web source maps, and the Build Distribution APK all under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)